### PR TITLE
Переработана настройка DNS-серверов

### DIFF
--- a/source/General.txt
+++ b/source/General.txt
@@ -39,13 +39,24 @@ dns-fallback-system = false
 # Если прямое разрешение DNS не работает, использовать прокси-сервер для DNS-запросов
 dns-direct-fallback-proxy = true
 
-# Перезаписывает системный DNS на указанные DoH-серверы. Google DNS — стандартный, Adguard предлагает блокировку рекламы. Хорошая практика для приватности и обхода фильтров.
+# Перезаписывает системный DNS на указанные DNS-over-TLS и DNS-over-HTTPS серверы. 
+# Порядок выбора серверов по приоритетности: 
+#  1. IPv6 DoT сервер Cloudflare (основной и резервный), 
+#  2. IPv4 DoT сервер Cloudflare (основной и резервный), 
+#  3. DoH сервер Cloudflare, 
+#  4. IPv6 Cloudflare (основной и резервный),
+#  5. IPv4 Cloudflare (основной и резервный),
+#  6. IPv6 DoT сервер Google (основной и резервный), 
+#  7. IPv4 DoT сервер Google (основной и резервный), 
+#  8. DoH сервер Google, 
+#  9. IPv6 Google (основной и резервный),
+# 10. IPv4 Google (основной и резервный).
 # Вы можете выбрать альтернативный DOH/DOT — https://github.com/curl/curl/wiki/DNS-over-HTTPS
-dns-server = https://dns.google/dns-query, https://dns.adguard-dns.com/dns-query, cloudflare-dns.com, dns.quad9.net, dns.adguard-dns.com, dns.comss.one
+dns-server = tls://2606:4700:4700::1112:853,tls://2606:4700:4700::1002:853,tls://1.1.1.2:853,tls://1.0.0.2:853,https://security.cloudflare-dns.com/dns-query,2606:4700:4700::1112,2606:4700:4700::1002,1.1.1.2,1.0.0.2, tls://2001:4860:4860::8888:853,tls://2001:4860:4860::8844:853,tls://8.8.8.8:853,tls://8.8.4.4:853,https://dns.google/dns-query,2001:4860:4860::8888,2001:4860:4860::88448.8.8.8,8.8.4.4
 
-# При сбое основного django Server — fallback на системный DNS. Можно указать другие DoH, но у вас стоит system для совместимости
-# fallback-dns-server = https://cloudflare-dns.com/dns-query, https://freedns.controld.com/p3
-fallback-dns-server = system
+# При сбое основного DNS — fallback на Yandex DNS или, в крайнем случае, системный DNS (от вашего интернет-провайдера)
+# Яндекс не используется в качестве основного сервера т.к. опирается на Национальную систему доменных имен (НСДИ): если Роскомнадзор удалит оттуда сайт, Яндекс должен будет подчиниться 
+fallback-dns-server = tls://77.88.8.88:853,https://safe.dot.dns.yandex.net/dns-query,2a02:6b8::feed:bad,77.88.8.88,system
 
 # Перехватывает DNS-запросы некоторых сервисов (Например, Netflix) на UDP/TCP порт 53 и направляет через программу
 hijack-dns = :53


### PR DESCRIPTION
серверы расставлены по приоритету - DoT, DoH, без шифрования. Сначала IPv6, если не получается - IPv4. Первый выбор - Cloudflare, бэкап - Гугл.

Яндекс ДНС добавлен как fallback перед провайдерским DNS