### PR TITLE
Добавлены подробные примеры настройки групп серверов

### DIFF
--- a/source/General.txt
+++ b/source/General.txt
@@ -82,9 +82,29 @@ include = sr_ru_extended.conf
 # URL-адрес обновления файла конфигурации
 update-url = https://cdn.jsdelivr.net/gh/misha-tgshv/shadowrocket-configuration-file@main/conf/sr_ru_public_lists.conf
 
-# Выбираем наиболее быстрый сервера для прокси
+# Выбираем наиболее быстрый сервер из нашей VLESS подписки для нужной нам цели. Например, у вашего VPN-провайдера могут быть серверы для доступа к YouTube без рекламы, серверы для доступа к AI-сервисам (ChatGPT, Claude, Gemini..), европейские серверы, американские. Мы объединим их в группы, из которых Shadowrocket будет выбирать самый шустрый сервер группы
+
 # [Proxy Group]
-# AUTO = url-test,interval=600,timeout=5,url=https://cp.cloudflare.com/generate_204,policy-regex-filter=*
+# AI-Group: выбирает быстрейший сервер из тех, у которых в описании есть слова "AI", "Нейро", или соотв. эмодзи:
+# AI-Group = url-test, policy-regex-filter=(AI|Нейро|🤖), interval=600, timeout=5, url=http://www.gstatic.com/generate_204
+# YouTube-Group: выбирает быстрейший сервер из тех, у которых в описании есть слова "YouTube", "Россия", или соотв. эмодзи:
+# YouTube-Group = url-test, policy-regex-filter=(YouTube|Россия|Russia|🇷🇺|🍿), interval=600, timeout=5, url=http://www.gstatic.com/generate_204
+# EU-Group: выбирает быстрейший европейский сервер:
+# EU-Group = url-test, policy-regex-filter=(Франция|France|🇫🇷|Испания|Spain|🇪🇸|Германия|Germany|🇩🇪|Польша|Poland|🇵🇱), interval=600, timeout=5, url=http://www.gstatic.com/generate_204
+# USA-Group: выбирает быстрейший американский сервер:
+# USA-Group = url-test, policy-regex-filter=(США|USA|🇺🇸), interval=600, timeout=5, url=http://www.gstatic.com/generate_204
+# Israel-Group: выбирает быстрейший израильский сервер (тамошние сайты банков и госуслуг плохо пускают из-за границы):
+Israel-Group = url-test, policy-regex-filter=(🇮🇱|Израиль|Israel), interval=600, timeout=5, url=http://www.gstatic.com/generate_204
+# AUTO: в эту группу попадут все серверы ЗА ИСКЛЮЧЕНИЕМ тех, у которых в названии есть "YouTube", "Россия" или эмодзи флага РФ - обратите внимание на то, что регулярное выражение отличается от групп выше
+AUTO = url-test, policy-regex-filter=^(?!.*(YouTube|Россия|🇷🇺)).*, interval=600, timeout=5, url=http://www.gstatic.com/generate_204
+# Как протестировать группы: добавьте в правила маршрутизации сервис проверки IP-адреса "2IP":
+# [Rule]
+# DOMAIN-SUFFIX,2ip.ua,EU-GROUP
+# DOMAIN-SUFFIX,2ip.ru,DIRECT
+# DOMAIN-SUFFIX,2ip.io,AUTO
+# Если вы зайдёте на 2ip.ua, вы должны увидеть адрес VPN-сервера из Европы.
+# Если зайдёте на 2ip.io - увидите адрес просто самого быстрого сервера (за исключением российских), который Shadowrocket выберет автоматически.
+# Если зайдёте на 2ip.ru - увидите свой исходный IP-адрес (произойдёт прямое подключение мимо VPN).
 
 # Опционально. Добавьте эти адреса в настройках программы Settings → GeoLite2 Database
 # Если у вас нет аккаунта на Maxmind и вы испольузуете финальное правило Proxy или Auto


### PR DESCRIPTION
Написаны подробные примеры как собирать VLESS-серверы в группы по назначению, и как потом использовать эти группы для выборочного роутинга