### PR TITLE
Added a missing website for identifying IP addresses

### DIFF
--- a/rules/domains_geo_detect.list
+++ b/rules/domains_geo_detect.list
@@ -92,6 +92,7 @@ DOMAIN-SUFFIX,ipv4-check-perf.radar.cloudflare.com
 DOMAIN-SUFFIX,ipv4-internet.yandex.net
 DOMAIN-SUFFIX,ipv6-check-perf.radar.cloudflare.com
 DOMAIN-SUFFIX,ipv6-internet.yandex.net
+DOMAIN-SUFFIX,ip.mail.ru
 DOMAIN-SUFFIX,ipverify.com
 DOMAIN-SUFFIX,ipw.cn
 DOMAIN-SUFFIX,ipwhois.io


### PR DESCRIPTION
Used in the Max Messenger spyware module within the HOST_REACHABILITY method

Check out https://habr.com/ru/articles/1006666/ at "Подробный реверс инжиниринг со ссылками под спойлером" section